### PR TITLE
Cleanup conf files

### DIFF
--- a/MSenseDevice/child_image/hci_ipc.conf
+++ b/MSenseDevice/child_image/hci_ipc.conf
@@ -1,23 +1,38 @@
+CONFIG_IPC_SERVICE=y
+CONFIG_MBOX=y
 
-CONFIG_DEBUG=n
-CONFIG_LOG=n
-CONFIG_MAIN_STACK_SIZE=4000
-CONFIG_LOG_BUFFER_SIZE=1024
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+
+CONFIG_MAIN_STACK_SIZE=512
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=512
+
+CONFIG_BT=y
+CONFIG_BT_HCI_RAW=y
+CONFIG_BT_MAX_CONN=16
+
+# The nRF5340 LFXO path is placed in external-clock bypass mode by the
+# application-core SDK patch. This selects that path and declares the
+# 5 ppm source using the tightest supported accuracy bin (0-20 ppm).
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
+CONFIG_CLOCK_CONTROL_NRF_K32SRC_20PPM=y
+
+# Default controller TX power at the antenna, in dBm. Change this value to
+# request a different supported power level (for example, 3 for +3 dBm).
+CONFIG_BT_CTLR_TX_PWR_ANTENNA=0
+
+# Keep Bluetooth LE 2 Mbps and coded PHY capabilities available for host-led
+# negotiation; these settings do not force either PHY on a connection.
+CONFIG_BT_CTLR_PHY_2M=y
+CONFIG_BT_CTLR_PHY_CODED=y
 
 
-#CONFIG_LOG_BACKEND_UART=y
-#CONFIG_LOG_BACKEND_UART=y
-#CONFIG_USE_SEGGER_RTT=y
-#CONFIG_PRINTK=y
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+CONFIG_BT_BUF_CMD_TX_COUNT=10
 
-#CONFIG_LOG_PRINTK=y
-#CONFIG_LOG_BACKEND_RTT=y
-
-CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=800
-
-#CONFIG_BT_CTLR=y
-CONFIG_BT_CTLR_TX_PWR_ANTENNA=3
-#CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=5000
-#CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=n
-#CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION=n
-#CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y 
+# Enable and adjust the below value as necessary
+# CONFIG_BT_BUF_EVT_RX_COUNT=16
+# CONFIG_BT_BUF_EVT_RX_SIZE=255
+# CONFIG_BT_BUF_ACL_RX_SIZE=255
+# CONFIG_BT_BUF_ACL_TX_SIZE=251
+# CONFIG_BT_BUF_CMD_TX_SIZE=255

--- a/MSenseDevice/prj.conf
+++ b/MSenseDevice/prj.conf
@@ -17,7 +17,6 @@ CONFIG_DEBUG_OPTIMIZATIONS=n
 #CONFIG_DEBUG_COREDUMP=y
 #CONFIG_DEBUG_COREDUMP_BACKEND_LOGGING=y
 CONFIG_DEBUG_INFO=y
-CONFIG_EXCEPTION_STACK_TRACE=y
 CONFIG_RESET_ON_FATAL_ERROR=y
 
 #Log config
@@ -91,9 +90,10 @@ CONFIG_LOG_BACKEND_FS_BUFFER=y
 #CONFIG_BOARD_ENABLE_DCDC_APP=n
 #CONFIG_BOARD_ENABLE_DCDC_NET=n
 
-# Clock Control. This KConfig Controls whether we use a Crystal (XTAL) or RC Oscilator.
+# LF clock source. The SDK bypass patch below configures the LFXO path for
+# our external 32.768 kHz clock.
+CONFIG_SOC_ENABLE_LFXO=y
 CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC=n
-CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION=n
 
 CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
 
@@ -149,8 +149,10 @@ CONFIG_DK_LIBRARY=y
 
 
 
-# Enable bluetooth and bonding
+# Bluetooth host configuration
 CONFIG_BT=y
+# The board selects IPC transport between the application host and network-core
+# controller; CONFIG_BT_HCI_IPC is not directly user-configurable.
 
 #CONFIG_BT_BONDABLE=y
 #CONFIG_BT_BONDING_REQUIRED=y
@@ -163,13 +165,14 @@ CONFIG_BT_MAX_CONN=1
 
 
 CONFIG_BT_PERIPHERAL=y
-#CONFIG_BT_GAP_PERIPHERAL_PREF_PARAMS=y
-# in BLE the host typically sets the minimum and maximum connection interval with which packets must be sent. 
-# however, the client can still request preferred parameters and the host can decide if it wants to accept them.
+# Zephyr enables peripheral preferred-parameter support by default. These
+# values specify the connection parameters requested from the central.
+CONFIG_BT_GAP_PERIPHERAL_PREF_PARAMS=y
+CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=y
 CONFIG_BT_PERIPHERAL_PREF_MAX_INT=40
 CONFIG_BT_PERIPHERAL_PREF_MIN_INT=24
 CONFIG_BT_PERIPHERAL_PREF_LATENCY=0
-#this is in miliseconds
+# This value is in 10 ms units (600 = 6 seconds).
 CONFIG_BT_PERIPHERAL_PREF_TIMEOUT=600
 CONFIG_BT_DEVICE_NAME="MSense4"
 
@@ -178,9 +181,15 @@ CONFIG_BT_DEVICE_NAME="MSense4"
 
 
 
-#CONFIG_BT_CTLR=y
-#CONFIG_BT_CTLR_TX_PWR_ANTENNA=-8
-#CONFIG_BT_CTLR_TX_PWR_MINUS_40=y
+# The Bluetooth controller runs in the network-core hci_ipc image. Configure
+# its settings, including TX power, in child_image/hci_ipc.conf.
+
+# Permit and automatically initiate PHY and data-length negotiation when a
+# connection is established.
+CONFIG_BT_PHY_UPDATE=y
+CONFIG_BT_AUTO_PHY_UPDATE=y
+CONFIG_BT_DATA_LEN_UPDATE=y
+CONFIG_BT_AUTO_DATA_LEN_UPDATE=y
 
 # for now, we don't use security, but we can re-enable if we want it.
 CONFIG_BT_SMP=n
@@ -191,7 +200,6 @@ CONFIG_BT_DIS_MANUF="SenseLab"
 CONFIG_BT_DIS_PNP=n
 CONFIG_BT_DIS_MODEL="5.0.3 NAND"
 CONFIG_BT_DIS_SETTINGS=n
-CONFIG_BT_MAX_PAIRED=1
 
 # Enable Battery service settings
 CONFIG_BT_BAS=y
@@ -244,11 +252,7 @@ CONFIG_FLASH_LOG_LEVEL_INF=y
 
 # Partition Manager Config
 
-CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY=n
-
 # Disk Driver Config
-CONFIG_DISK_DRIVER_FLASH=n
-CONFIG_DISK_DRIVER_RAM=n
 CONFIG_DISK_DRIVER_RAW_NAND=y
 CONFIG_DISK_DRIVER_DHARA=n
 

--- a/MSenseDevice/sysbuild.cmake
+++ b/MSenseDevice/sysbuild.cmake
@@ -1,0 +1,8 @@
+# Apply the project-owned configuration fragment to the network-core HCI IPC
+# image selected in sysbuild.conf.
+if(SB_CONFIG_NETCORE_HCI_IPC)
+  add_overlay_config(
+    hci_ipc
+    ${CMAKE_CURRENT_LIST_DIR}/child_image/hci_ipc.conf
+  )
+endif()

--- a/MSenseDevice/tools/README.md
+++ b/MSenseDevice/tools/README.md
@@ -1,0 +1,87 @@
+# nRF Connect SDK build scripts
+
+`ncs-env.ps1` configures a PowerShell process to use the nRF Connect SDK and
+toolchain required by this application. `ncs-build.ps1` loads that environment
+and runs the same sysbuild-oriented `west build` configuration used by the
+existing VS Code build directory.
+
+The scripts do not change machine-wide environment variables, VS Code settings,
+or the nRF Connect VS Code extension. They affect only the PowerShell process
+that runs them and any child processes it starts.
+
+## Build this project
+
+From the `MSenseDevice` directory, run:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\ncs-build.ps1 -Pristine
+```
+
+Omit `-Pristine` for an incremental build. The default output directory is
+`MSenseDevice\build`; do not run this script and a VS Code build against that
+same directory at the same time.
+
+## Required installation
+
+This project is currently configured and verified with:
+
+| Component | Required location |
+| --- | --- |
+| nRF Connect SDK | `C:\ncs\v2.9.3` |
+| Nordic toolchain | `C:\ncs\toolchains\b620d30767` |
+| Application | `MSenseDevice` |
+| Target board | `nrf5340dk/nrf5340/cpuapp` |
+
+Install the exact SDK version through Nordic's nRF Connect tooling and ensure
+the SDK workspace has been initialized. From the SDK root, the following should
+succeed in a normal NCS terminal:
+
+```powershell
+west topdir
+west list zephyr nrf
+```
+
+The project uses sysbuild to include MCUboot and the nRF5340 network-core HCI
+image. Do not replace the supplied `west build` command with a direct CMake
+build or a single-image build.
+
+## Using another machine or installation path
+
+Supply the installed locations directly to the build script:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\tools\ncs-build.ps1 `
+  -NcsRoot 'D:\ncs\v2.9.3' `
+  -ToolchainRoot 'D:\ncs\toolchains\b620d30767' `
+  -Pristine
+```
+
+The same `-NcsRoot` and `-ToolchainRoot` parameters are available on
+`ncs-env.ps1` when an interactive shell needs the environment. The toolchain
+and SDK versions must remain compatible with the project; do not silently
+substitute a newer NCS release.
+
+The scripts require these files within the supplied paths:
+
+```text
+<NcsRoot>\zephyr
+<ToolchainRoot>\opt\bin\python.exe
+<ToolchainRoot>\opt\bin\cmake.exe
+<ToolchainRoot>\opt\bin\ninja.exe
+<ToolchainRoot>\opt\bin\Scripts\west.exe
+```
+
+## Git ownership when invoked by Codex
+
+Codex can run under a different Windows identity from the person who installed
+the SDK. Git then rejects the SDK repositories as "dubious ownership," which
+prevents west from resolving imported manifests. `ncs-env.ps1` derives a
+process-local `safe.directory` exception from `-NcsRoot`; it does not modify
+global Git configuration.
+
+## SDK modifications
+
+The active SDK checkout contains project-specific modifications that are not
+made by these scripts. Reproducing a build on another computer requires the
+same SDK revision and all documented project patches. Verify and reconcile the
+repository's patch instructions before relying on a fresh NCS installation.

--- a/MSenseDevice/tools/ncs-build.ps1
+++ b/MSenseDevice/tools/ncs-build.ps1
@@ -1,0 +1,50 @@
+[CmdletBinding()]
+param(
+    [switch]$Pristine,
+    [string]$BuildDirectory,
+    [string]$NcsRoot,
+    [string]$ToolchainRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$environmentArguments = @{}
+
+if ($PSBoundParameters.ContainsKey('NcsRoot')) {
+    $environmentArguments.NcsRoot = $NcsRoot
+}
+
+if ($PSBoundParameters.ContainsKey('ToolchainRoot')) {
+    $environmentArguments.ToolchainRoot = $ToolchainRoot
+}
+
+. (Join-Path $PSScriptRoot 'ncs-env.ps1') @environmentArguments
+
+$app = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+if (-not $BuildDirectory) {
+    $BuildDirectory = Join-Path $app 'build'
+}
+
+$west = Join-Path $env:NCS_TOOLCHAIN_ROOT 'opt\bin\Scripts\west.exe'
+
+$westArgs = @(
+    'build'
+    '--build-dir', $BuildDirectory
+    $app
+)
+
+if ($Pristine) {
+    $westArgs += '--pristine'
+}
+
+$westArgs += @(
+    '--board', 'nrf5340dk/nrf5340/cpuapp'
+    '--'
+    '-DNCS_TOOLCHAIN_VERSION=NONE'
+    '-DCONF_FILE=prj.conf'
+    '-DDTC_OVERLAY_FILE=nrf5340dk_nrf5340_cpuapp.overlay'
+)
+
+& $west @westArgs
+exit $LASTEXITCODE

--- a/MSenseDevice/tools/ncs-env.ps1
+++ b/MSenseDevice/tools/ncs-env.ps1
@@ -1,0 +1,42 @@
+[CmdletBinding()]
+param(
+    [string]$NcsRoot = 'C:\ncs\v2.9.3',
+    [string]$ToolchainRoot = 'C:\ncs\toolchains\b620d30767'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$bin = Join-Path $ToolchainRoot 'opt\bin'
+$scripts = Join-Path $bin 'Scripts'
+
+foreach ($requiredPath in @(
+    $NcsRoot,
+    (Join-Path $NcsRoot 'zephyr'),
+    (Join-Path $scripts 'west.exe'),
+    (Join-Path $bin 'cmake.exe'),
+    (Join-Path $bin 'ninja.exe'),
+    (Join-Path $bin 'python.exe')
+)) {
+    if (-not (Test-Path -LiteralPath $requiredPath)) {
+        throw "Required nRF Connect SDK path is missing: $requiredPath"
+    }
+}
+
+$env:NCS_ROOT = $NcsRoot
+$env:ZEPHYR_BASE = Join-Path $NcsRoot 'zephyr'
+$env:WEST_PYTHON = Join-Path $bin 'python.exe'
+$env:NCS_TOOLCHAIN_ROOT = $ToolchainRoot
+
+# Codex inherits both Path and PATH. PowerShell resolves the former, while the
+# Python process that runs west resolves the latter. Replace both with one
+# canonical PATH so west can locate CMake and Ninja.
+$existingPath = [System.Environment]::GetEnvironmentVariable('Path', 'Process')
+[System.Environment]::SetEnvironmentVariable('Path', $null, 'Process')
+[System.Environment]::SetEnvironmentVariable('PATH', "$scripts;$bin;$existingPath", 'Process')
+
+# Codex runs under a different Windows identity than the owner of the NCS
+# checkout. Limit the Git trust exception to this SDK and this process tree.
+$gitSafeDirectory = ($NcsRoot -replace '\\', '/').TrimEnd([char]'/') + '/*'
+$env:GIT_CONFIG_COUNT = '1'
+$env:GIT_CONFIG_KEY_0 = 'safe.directory'
+$env:GIT_CONFIG_VALUE_0 = $gitSafeDirectory


### PR DESCRIPTION
These are changes / cleanups I am proposing for the ECG mote that I deem worthy of backporting to the PPG. More to come.

The conf file child_image/hci_ipc.conf (i.e., the network core settings) was not included in the build. Instead the Zephyr default sample was being used. This was largely not a problem but it did reduce Tx power from +3dBm to +0dBm

I fixed the build to add our conf file back in, however I copied over the sample defaults for a clean start. None should matter too much although this needs a little testing. I also explicitly included some previously implicit default values for clarity. I kept the reduced Tx power so note that it can be increased to +3dBm if desired. Ask me if you'd like more information on any setting in particular.

I also did a treatment to the prj.conf file (application core settings) . I removed some unused settings and edited some comments. Made some implicit defaults explicit.

All of this is to hopefully make it more clear where a particular setting is done although DT still makes this hard. There should be no functional change.

I also added a powershell wrapper script to allow AI agents to build nRF SDK / west projects instead of having to initiate under VScode. At least Codex needs this, did not try Claude or others. I don't normally do this but it is convenient sometimes. Add a note about the tools directory to your AGENTS.md file or whatever. The wrapper is currently fragile and if you have different tool paths or change the SDK or toolchain it will probably need adjustment.